### PR TITLE
Javadoc: Add package-info.java files

### DIFF
--- a/swing/src/bbct/common/data/package-info.java
+++ b/swing/src/bbct/common/data/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of BBCT for Android.
+ *
+ * Copyright 2012 codeguru <codeguru@users.sourceforge.net>
+ *
+ * BBCT for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BBCT for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * Classes to access the underlaying data store in the Swing version of BBCT.
+ */
+package bbct.common.data;

--- a/swing/src/bbct/common/exceptions/package-info.java
+++ b/swing/src/bbct/common/exceptions/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of BBCT for Android.
+ *
+ * Copyright 2012 codeguru <codeguru@users.sourceforge.net>
+ *
+ * BBCT for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BBCT for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * Exceptions used throughout the Swing version of BBCT.
+ */
+package bbct.common.exceptions;

--- a/swing/src/bbct/common/package-info.java
+++ b/swing/src/bbct/common/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of BBCT for Android.
+ *
+ * Copyright 2012 codeguru <codeguru@users.sourceforge.net>
+ *
+ * BBCT for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BBCT for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * Data used throughout the Swing version of BBCT.
+ */
+package bbct.common;

--- a/swing/src/bbct/swing/gui/event/package-info.java
+++ b/swing/src/bbct/swing/gui/event/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of BBCT for Android.
+ *
+ * Copyright 2012 codeguru <codeguru@users.sourceforge.net>
+ *
+ * BBCT for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BBCT for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * Event handlers for the Swing version of BBCT.
+ */
+package bbct.swing.gui.event;

--- a/swing/src/bbct/swing/gui/inputverifiers/package-info.java
+++ b/swing/src/bbct/swing/gui/inputverifiers/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of BBCT for Android.
+ *
+ * Copyright 2012 codeguru <codeguru@users.sourceforge.net>
+ *
+ * BBCT for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BBCT for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * {@link InputVerifiers} for the Swing version of BBCT.
+ */
+package bbct.swing.gui.inputverifiers;

--- a/swing/src/bbct/swing/gui/package-info.java
+++ b/swing/src/bbct/swing/gui/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of BBCT for Android.
+ *
+ * Copyright 2012 codeguru <codeguru@users.sourceforge.net>
+ *
+ * BBCT for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BBCT for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * GUI components for the Swing version of BBCT.
+ */
+package bbct.swing.gui;

--- a/swing/src/bbct/swing/package-info.java
+++ b/swing/src/bbct/swing/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of BBCT for Android.
+ *
+ * Copyright 2012 codeguru <codeguru@users.sourceforge.net>
+ *
+ * BBCT for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BBCT for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * The driver class of the Swing version of BBCT.
+ */
+package bbct.swing;


### PR DESCRIPTION
Add package-info.java files to packages in the Swing version
of BBCT.
